### PR TITLE
Add new osxGNUCONDAdbl option to the makefile for the MTCKD model.

### DIFF
--- a/DATA/MT_CKD_continuum/cntnm.H2O_N2/build/makefile.common
+++ b/DATA/MT_CKD_continuum/cntnm.H2O_N2/build/makefile.common
@@ -48,6 +48,7 @@ default:
 	echo 'osxABSOFTdbl : OSX using Absoft PRO Fortran and double precision'
 	echo 'osxABSOFTsgl : OSX using Absoft PRO Fortran and single precision'
 	echo 'osxGNUdbl    : OSX using GNU Fortran and double precision'
+	echo 'osxGNUCONDAdbl : OSX using GNU Fortran installed with conda and double precision'
 	echo 'osxGNUsgl    : OSX using GNU Fortran and single precision'
 	echo 'osxIBMdbl    : OSX using IBM XL Fortran and double precision'
 	echo 'osxIBMsgl    : OSX using IBM XL Fortran and single precision'
@@ -55,8 +56,8 @@ default:
 	echo 'mingwGNUsgl  : Window unix shell environment using gfortran and single precision'
 	echo 'aixIBMsgl    : AIX using IBM XL Fortran and double precision'
 	echo 'aixIBMsgl    : AIX using IBM XL Fortran and single precision'
-	echo 
-	
+	echo
+
 
 ###############################
 # Load line
@@ -126,14 +127,14 @@ makedir :
 clean:
 	-rm -rf *.o *.mod
 	-rm -rf $(PRODUCT)_*_$(VERSION)_*.obj
-	
+
 cleanall:
 	-rm -rf *.o *.mod
 	-rm -r *_*_$(VERSION)_*.obj
 
 cleanmods:
 	-rm -rf *.mod
-	
+
 #*************************************************************
 # SUN/SOLARIS OPERATING SYSTEM
 #*************************************************************
@@ -207,7 +208,7 @@ linuxPGIsgl:
 	FC=pgf90 \
 	FCFLAG="-fast" \
 	UTIL_FILE=util_linux_pgi.f90
-	
+
 ##############################################################
 # linux using gfortran and double precision
 ##############################################################
@@ -312,7 +313,7 @@ osxABSOFTdbl:
 # OSX using Absoft PRO Fortran and single precision
 ##############################################################
 
-osxABSOFTsgl:	
+osxABSOFTsgl:
 	${MAKE} -f ${MAKEFILE} all P_TYPE=sgl FC_TYPE=intel \
 	PLTFRM=OS_X \
 	FC=absoft \
@@ -328,6 +329,17 @@ osxGNUdbl:
 	PLTFRM=OS_X  \
 	FC=gfortran \
 	FCFLAG=" -fdefault-integer-8 -fdefault-real-8 -frecord-marker=4" \
+	UTIL_FILE=util_gfortran.f90
+
+##############################################################
+# OSX using GNU Fortran (with conda-installed gfortran_osx-64) and double precision
+##############################################################
+
+osxGNUCONDAdbl:
+	${MAKE} -f ${MAKEFILE} all P_TYPE=dbl FC_TYPE=gnu \
+	PLTFRM=OS_X  \
+	FC=gfortran \
+	FCFLAG=" -fdefault-integer-8 -fdefault-real-8 -frecord-marker=4 -Wl,-rpath,${CONDA_PREFIX}/lib" \
 	UTIL_FILE=util_gfortran.f90
 
 ##############################################################

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PyRADS
 PyRADS is the Python line-by-line RADiation model for planetary atmosphereS. PyRADS is a radiation code that can provide line-by-line spectral resolution, yet is written in Python and so is flexible enough to be useful in teaching.
 
-For Earth-like atmospheres, PyRADS currently uses HITRAN 2016 line lists (http://hitran.org/) and the MTCKD continuum model (http://rtweb.aer.com/continuum_frame.html). 
+For Earth-like atmospheres, PyRADS currently uses HITRAN 2016 line lists (http://hitran.org/) and the MTCKD continuum model (http://rtweb.aer.com/continuum_frame.html).
 
 Currently, PyRADS is only valid for longwave calculations (no scattering).
 
@@ -15,11 +15,12 @@ References:
 2) Manually compile the MTCKD model:
 - cd $PyRADS/DATA/MT_CKD_continuum/cntnm.H2O_N2/build
 - (on a Mac) make -f make_cntnm osxGNUdbl
+- (on a Mac if you are using gfortran installed with conda) make -f make_cntnm osxGNUCONDAdbl
 
 3) Run test scripts
 
-To compute outgoing longwave radiation (OLR) in W/m2 for a given surface temperature: 
-- cd $PyRADS/Test01.olr 
+To compute outgoing longwave radiation (OLR) in W/m2 for a given surface temperature:
+- cd $PyRADS/Test01.olr
 - python compute_olr_h2o.py
 
 To compute OLRs for a set of surface temperatures and save the resulting output to txt:


### PR DESCRIPTION
Closes #5 

This just adds a new option to the makefile for people trying to build the MTCKD code out of the box with conda-installed gfortran. The instructions in the README are updated with this info.