### PR TITLE
Add Python 2/3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Compiled python modules.
+*.pyc
+# Compiled fortran objects, modules and extensions
+*.o
+*.mod
+*.so
+*.so.dSYM
+
+*.DS_Store

--- a/Test01.olr/compute_olr_h2o.py
+++ b/Test01.olr/compute_olr_h2o.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import numpy as np
 import sys,os
 
@@ -39,10 +40,10 @@ params.RH = 1.             # relative humidity
 N_press = 15       # for testing only!
 dwavenr = 0.1     #  for testing only!
 
-#N_press = 60       # 
+#N_press = 60       #
 wavenr_min = 0.1   # [cm^-1]
 wavenr_max = 3500. #
-#dwavenr = 0.01     # 
+#dwavenr = 0.01     #
 
 Tstrat = 150.      # stratospheric temperature
 
@@ -54,11 +55,11 @@ Ts = 300.
 ### -----------------------------------
 ## MAIN LOOP
 
-print "wavenr_min,wavenr_max,dwave [cm^-1] = %.4f,%.4f,%.4f" % (wavenr_min,wavenr_max,dwavenr)
-print "\n"
-print "N_press = %.1f" % N_press
-print "\n"
-print "Surface temperature = %.1f K" % Ts
+print( "wavenr_min,wavenr_max,dwave [cm^-1] = %.4f,%.4f,%.4f" % (wavenr_min,wavenr_max,dwavenr))
+print( "\n")
+print( "N_press = %.1f" % N_press)
+print( "\n")
+print( "Surface temperature = %.1f K" % Ts)
 
 
 # setup grid:
@@ -78,5 +79,4 @@ g.B = np.pi* pyrads.Planck.Planck_n( g.wave, T_2D )    # [press x wave]
 olr_spec = pyrads.Get_Fluxes.Fplus_alternative(0,g) # (spectrally resolved=irradiance)
 olr = simps(olr_spec,g.n)
 
-print "OLR = ",olr
-    
+print( "OLR = ",olr)

--- a/Test02.runaway/compute_olr_h2o.01.100RH.py
+++ b/Test02.runaway/compute_olr_h2o.01.100RH.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import numpy as np
 import sys,os
 
@@ -36,12 +37,12 @@ params.RH = 1.             # relative humidity
 # ---
 ## setup resolution (vertical,spectral)
 
-#N_press = 60       # 
-N_press = 15       # 
+#N_press = 60       #
+N_press = 15       #
 wavenr_min = 0.1   # [cm^-1]
 wavenr_max = 3500. #
-#dwavenr = 0.01     # 
-dwavenr = 0.1     # 
+#dwavenr = 0.01     #
+dwavenr = 0.1     #
 
 Tstrat = 150.      # stratospheric temperature
 
@@ -55,7 +56,7 @@ filename = 'output.compute_olr_h2o.01.100RH.txt'
 saveOutput = True  # Save the output/plots? [Yes/No]
 if saveOutput:
     OUTDIR = "./"
-    print "Saving output to ",OUTDIR
+    print( "Saving output to ",OUTDIR)
     if not os.path.isdir( OUTDIR ):
         os.makedirs( OUTDIR )
 
@@ -75,11 +76,11 @@ if saveOutput:
     f.write("\n")
 
     f.close()
-        
+
     ## main loop here
     for Ts in Ts_grid:
         f = open(OUTDIR+filename,'a')
-        
+
         # setup grid:
         g = pyrads.SetupGrids.make_grid( Ts,Tstrat,N_press,wavenr_min,wavenr_max,dwavenr,params, RH=params.RH )
 
@@ -108,11 +109,10 @@ if saveOutput:
         # Simple feedback model (like above, without normalization)
         weight = np.pi* pyrads.Planck.dPlanckdT_n( g.n,Ts )
         lam = trapz( np.exp(-g.tau[-1,:]) * weight,x=g.n )
-        
-        print "\n",Ts,g.ps/1e5,olr,surf, "\n"
-        
+
+        print( "\n",Ts,g.ps/1e5,olr,surf, "\n")
+
         f.write("%.2f,\t%.4f,\t%.8f,\t%.8f,\t%.8f,\t%.8f" % (Ts,g.ps/1e5,olr,surf,trans,lam) )
         f.write("\n")
 
         f.close()
-    

--- a/pyrads/Absorption_Continuum.py
+++ b/pyrads/Absorption_Continuum.py
@@ -1,6 +1,6 @@
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 import numpy as np
-import phys
+from . import phys
 
 '''
 Implement functions that return absorption cross-sections

--- a/pyrads/Absorption_Continuum.py
+++ b/pyrads/Absorption_Continuum.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import numpy as np
 import phys
 
@@ -40,7 +41,7 @@ def get_H2OSelfContinuum(wave,T,pH2O,extrapolate=True):
         mask = wave>3000.
         kappa1 = np.exp(-6.0055 + -0.0021363*(3000.-2500.) + 6.4723e-07*(3000.-2500.)**2 +
                                -1.493e-08*(3000.-2500.)**3 + 2.5621e-11*(3000.-2500.)**4 +
-                               7.328e-14*(3000.-2500.)**5)    
+                               7.328e-14*(3000.-2500.)**5)
         kappaC[mask] = kappa1
 
         # interpolate in between:
@@ -58,6 +59,3 @@ def get_H2OSelfContinuum(wave,T,pH2O,extrapolate=True):
     # Temperature dependence & rescale for partial pressure:
     Tfac = (296./T)**4.25
     return kappaC *Tfac *(pH2O/1e4)
-
-
-

--- a/pyrads/Absorption_Continuum_MTCKD.py
+++ b/pyrads/Absorption_Continuum_MTCKD.py
@@ -1,7 +1,7 @@
 from __future__ import division, print_function, absolute_import
 import os
 import numpy
-import phys
+from . import phys
 import time
 
 '''

--- a/pyrads/Absorption_Continuum_MTCKD.py
+++ b/pyrads/Absorption_Continuum_MTCKD.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 import os
 import numpy
 import phys

--- a/pyrads/Absorption_Continuum_MTCKD.py
+++ b/pyrads/Absorption_Continuum_MTCKD.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import os
 import numpy
 import phys
@@ -12,7 +13,7 @@ Fixed the scaling in 'get_H2OContinuum'.
 Tau computed with these coefficients now matches tau natively computed by MTCKD.
 
 UPDATE: (29.01.2018)
-To allow these scripts to run parallel within the same dir, 
+To allow these scripts to run parallel within the same dir,
 create all input/output files within a dummy directory.
 For a unique directory label, use time.time() stamp.
 '''
@@ -33,7 +34,7 @@ mtckd_exe_default = mtckd_exe_H2O_N2      # !
 
 
 ### -----------------------------------
-### Given wavenumber, (T,p,q), return total specific absorption crosssection for 
+### Given wavenumber, (T,p,q), return total specific absorption crosssection for
 ### continuum. Include both H2O self-continuum plus N2-H2O continuum.
 ###
 ### INPUT: wave -> VECTOR;      p,T,q -> SCALARS!
@@ -61,10 +62,10 @@ def get_H2OContinuum(wave,T,p_tot,p_H2O,exe_file=None):
 
     kappa_self0 = cross_self * 0.1 * phys.N_avogadro/phys.H2O.MolecularWeight
     kappa_foreign0 = cross_foreign * 0.1 * phys.N_avogadro/phys.H2O.MolecularWeight  # here: also m_H2O
-    
-    # Combine coefficients. Apply rescaling here. 
+
+    # Combine coefficients. Apply rescaling here.
     kappa0 = kappa_self0 * (p_H2O/p_tot) + kappa_foreign0 * ((p_tot-p_H2O)/p_tot)  # self + foreign broadening
-        
+
     # Now rescale for p,T
     #    (test passed: without this scaling, can't match MTCKD's optical depths at T>>296K. with, it can.)
     kappa0 = kappa0 * (p_tot/1.013e5)*(296./T)
@@ -76,7 +77,7 @@ def get_H2OContinuum(wave,T,p_tot,p_H2O,exe_file=None):
 
 
 ### -----------------------------------
-### Given wavenumber, (T,p,q), return total optical depth for 
+### Given wavenumber, (T,p,q), return total optical depth for
 ### continuum. Include both H2O self-continuum plus N2-H2O continuum.
 ###
 ### INPUT: wave -> VECTOR;      p,T,q -> SCALARS!
@@ -116,7 +117,7 @@ def get_coefficients(p,T,pathlength,vmr_h2o,exe_file=None,clean_files=True):
 
     #
     stamp = time.time()
-    tmp_dir = "./tmp_mtckd_%.5f" % stamp   # create a unique tmp dir    
+    tmp_dir = "./tmp_mtckd_%.5f" % stamp   # create a unique tmp dir
     os.mkdir( tmp_dir )
     os.chdir( tmp_dir )
     #print "current working directory: ",os.getcwd()
@@ -130,7 +131,7 @@ def get_coefficients(p,T,pathlength,vmr_h2o,exe_file=None,clean_files=True):
     #
     if clean_files:
         os.remove( tmp_dir + '/INPUT')       # clean up tmp files
-        os.remove( tmp_dir + '/WATER.COEF')  
+        os.remove( tmp_dir + '/WATER.COEF')
         os.remove( tmp_dir + '/CNTNM.OPTDPT')
         os.rmdir( tmp_dir )
 
@@ -150,7 +151,7 @@ def get_tau(p,T,pathlength,vmr_h2o,exe_file=None,clean_files=True):
 
     #
     stamp = time.time()
-    tmp_dir = "./tmp_mtckd_%.5f" % stamp   # create a unique tmp dir    
+    tmp_dir = "./tmp_mtckd_%.5f" % stamp   # create a unique tmp dir
     os.mkdir( tmp_dir )
     os.chdir( tmp_dir )
 
@@ -162,8 +163,8 @@ def get_tau(p,T,pathlength,vmr_h2o,exe_file=None,clean_files=True):
 
     if clean_files:
         os.remove( tmp_dir + '/INPUT')       # clean up tmp files
-        os.remove( tmp_dir + '/WATER.COEF')  
-        os.remove( tmp_dir + '/CNTNM.OPTDPT')        
+        os.remove( tmp_dir + '/WATER.COEF')
+        os.remove( tmp_dir + '/CNTNM.OPTDPT')
         os.rmdir( tmp_dir )
 
     return wave,tau
@@ -175,7 +176,7 @@ def get_tau(p,T,pathlength,vmr_h2o,exe_file=None,clean_files=True):
 ### -----------------------------------
 ### Run MTCKD for given input parameters
 ###
-### Note: mt_ckd needs [p] = mb, [path] = cm. 
+### Note: mt_ckd needs [p] = mb, [path] = cm.
 ###
 
 def run_mtckd(p,T,pathlength,vmr_h2o,exe_file,suppress_stdout=True):
@@ -192,14 +193,14 @@ def run_mtckd(p,T,pathlength,vmr_h2o,exe_file,suppress_stdout=True):
     if suppress_stdout:
         os.system( exe_file + " < " + input_file + " > /dev/null")
     else:
-        print "================================================"
-        print "===   RUN MT_CKD CONTINUUM                   ==="
-        print "==="
+        print( "================================================")
+        print( "===   RUN MT_CKD CONTINUUM                   ===")
+        print( "===")
         os.system( exe_file + " < " + input_file )
-        print "==="
-        print "==="
-        print "================================================"
-    
+        print( "===")
+        print( "===")
+        print( "================================================")
+
 
 ### -----------------------------------
 ### Given output txt file, cut off header and extract data
@@ -233,9 +234,7 @@ def read_mtckd_output(file):
         body = txt.split("MOLECULAR AMOUNTS (MOL/CM**2) BY LAYER \n")[-1]
 
         data = numpy.genfromtxt(body.split('\n'), skip_header=6)  # careful about cutoffs!
-        
+
         wave = data[:,0]
         tau = data[:,1]
         return wave,tau
-
-

--- a/pyrads/Absorption_Crosssections_HITRAN2016.py
+++ b/pyrads/Absorption_Crosssections_HITRAN2016.py
@@ -522,16 +522,20 @@ def loadSpectralLines(molName,minWave=None,maxWave=None):
     line = f.readline()
     while len(line)>0:
         count += 1
-        isoIndex = string.atoi(get(line,iso))
-        n = string.atof(get(line,waveNum))
+        #isoIndex = string.atoi(get(line,iso))
+        isoIndex = int(get(line,iso))
+        #n = string.atof(get(line,waveNum))
+        n = float(get(line,waveNum))
         #DKOLL:
         if n<minWave:
             pass   # skip to next line
         elif n>maxWave:
             break  # ignore rest of file
         else:
-            S = string.atof(get(line,lineStrength))
-            El = string.atof(get(line,Elow))
+            #S = string.atof(get(line,lineStrength))
+            S = float(get(line,lineStrength))
+            #El = string.atof(get(line,Elow))
+            El = float(get(line,Elow))
             #Convert line strength to (m**2/kg)(cm**-1) units
             #The cm**-1 unit is there because we still use cm**-1
             #as the unit of wavenumber, in accord with standard
@@ -540,9 +544,12 @@ def loadSpectralLines(molName,minWave=None,maxWave=None):
             #**ToDo: Put in correct molecular weight for the
             #        isotope in question.
             S = .1*(phys.N_avogadro/molecules[molName][1])*S
-            gamAir = string.atof(get(line,airWidth))
-            gamSelf = string.atof(get(line,selfWidth))
-            TemperatureExponent = string.atof(get(line,TExp))
+            #gamAir = string.atof(get(line,airWidth))
+            gamAir = float(get(line,airWidth))
+            #gamSelf = string.atof(get(line,selfWidth))
+            gamSelf = float(get(line,selfWidth))
+            #TemperatureExponent = string.atof(get(line,TExp))
+            TemperatureExponent = float(get(line,TExp))
             if  isoIndex == 1:
                 waveList.append(n)
                 sList.append(S)

--- a/pyrads/Absorption_Crosssections_HITRAN2016.py
+++ b/pyrads/Absorption_Crosssections_HITRAN2016.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 ### THIS SCRIPT IS BASED ON PyTran, WHICH IS PART OF THE COURSEWARE IN
 ###  Pierrehumbert, 2010, Principles of Planetary Climate
 ###

--- a/pyrads/Absorption_Crosssections_HITRAN2016.py
+++ b/pyrads/Absorption_Crosssections_HITRAN2016.py
@@ -80,8 +80,8 @@ from __future__ import division, print_function, absolute_import
 #---------------------------------------------------------
 
 import string,math
-from ClimateUtilities import *
-import phys
+from .ClimateUtilities import *
+from . import phys
 import os
 
 #Path to the datasets

--- a/pyrads/Absorption_Crosssections_HITRAN2016.py
+++ b/pyrads/Absorption_Crosssections_HITRAN2016.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 ### THIS SCRIPT IS BASED ON PyTran, WHICH IS PART OF THE COURSEWARE IN
 ###  Pierrehumbert, 2010, Principles of Planetary Climate
 ###
@@ -61,7 +62,7 @@
 #atmosphere). If you want to modify the code to look at minor
 #isotopologues, it is important to note that the HITRAN database
 #downweights the line strengths for each isotopologue according
-#to relative abundance in Earth's atmosphere. 
+#to relative abundance in Earth's atmosphere.
 #--------------------------------------------------------
 #
 #Change Log
@@ -97,7 +98,7 @@ Sum = 0
 fieldStart = [0]
 for length in fieldLengths:
     Sum += length
-    fieldStart.append(Sum)   
+    fieldStart.append(Sum)
 iso = 1
 waveNum = 2
 lineStrength = 3
@@ -116,7 +117,7 @@ def QGenericLin(T): #Approx. for linear molecules like CO2
 def QGenericNonLin(T): #Approx for nonlinear molecules like H2O
     return T**1.5
 #**ToDo: Provide actual partition functions for CO2, H2O and CH4
-    
+
 #Molecule numbers and molecular weights
 #Add more entries here if you want to do other
 #molecules in the HITRAN database. These entries are
@@ -164,7 +165,7 @@ def makeEsumTable(waveStart,waveEnd,Delta=50.,N=21):
 		c.addCurve(hist,header2)
 		wave += Delta
 	return c
-                
+
 #Note: Log quartile values are exponentiated for plotting
 def plotLogQuartiles(bandWidth):
     waveList = []
@@ -182,8 +183,8 @@ def plotLogQuartiles(bandWidth):
     c.addCurve([math.exp(stat[3]) for stat in statsList],'q75')
     c.addCurve([math.exp(stat[4]) for stat in statsList],'Max')
     return c
-    
-    
+
+
 
 def logQuartiles(waveRange):
     i1 = numpy.searchsorted(waveGrid,waveRange[0])
@@ -200,7 +201,7 @@ def quartiles(data):
     else:
         return [-1.e20,-1.e20,-1.e20,-1.e20,-1.e20]
 
-    
+
 #Utility to compute histogram of absorption data
 #Returns bins, histogram and cumulative PDF
 def histo(data,nBins=10,binMin=None,binMax=None):
@@ -209,7 +210,7 @@ def histo(data,nBins=10,binMin=None,binMax=None):
         binMid = numpy.zeros(nBins-1,numpy.Float)
         hist = numpy.zeros(nBins-1,numpy.Float)
         hist[0] = 1.
-        binMid[0] = -1.e30 
+        binMid[0] = -1.e30
         cumHist = numpy.zeros(nBins-1,numpy.Float)+1.
         return binMid,hist,cumHist
     #
@@ -274,7 +275,7 @@ def computeAbsorption(waveGrid,getGamma,p,T,dWave,numWidths = 1000.):
         #for temperature T, but it can become important on the low frequency
         #side, and is easy to incorporate.
         Tfact1 = (1.- math.exp(-100.*(phys.h*phys.c/phys.k)*n/T))/ \
-              (1.- math.exp(-100.*(phys.h*phys.c/phys.k)*n/296.))   
+              (1.- math.exp(-100.*(phys.h*phys.c/phys.k)*n/296.))
         #The following has the incorrect algebraic prefactor used in
         #  the original version of PyTran (see Errata/Updates document)
         #S = sList[i]*(T/296.)**TExpList[i]*Tfact
@@ -317,7 +318,7 @@ def computeAbsorption_fixedCutoff(waveGrid,getGamma,p,T,dWave,numWidths=25.,remo
         #for temperature T, but it can become important on the low frequency
         #side, and is easy to incorporate.
         Tfact1 = (1.- math.exp(-100.*(phys.h*phys.c/phys.k)*n/T))/ \
-              (1.- math.exp(-100.*(phys.h*phys.c/phys.k)*n/296.))   
+              (1.- math.exp(-100.*(phys.h*phys.c/phys.k)*n/296.))
         #The following has the incorrect algebraic prefactor used in
         #  the original version of PyTran (see Errata/Updates document)
         #S = sList[i]*(T/296.)**TExpList[i]*Tfact
@@ -413,7 +414,7 @@ def plotP(n,T=296.,numWidths = 1000.):
 	c.addCurve(absp)
 	c.YlogAxis = c.XlogAxis = True
 	return c
-        
+
 #Gets the fieldNum'th data item from a Hitran2004 record
 def get(line,fieldNum):
     return line[fieldStart[fieldNum]:fieldStart[fieldNum]+fieldLengths[fieldNum]]
@@ -460,13 +461,13 @@ def OLRspec(pathMax):
     B = numpy.array([Planck(w,TT) for w in waveGrid])
     OLR += B*trans
     return OLR
-    
+
 #Computes a function smoothed over specified wavenumber band
 def smooth(wAvg,data):
     navg = int(wAvg/dWave)
     nmax = len(waveGrid)-navg
     return [numpy.average(data[i:i+navg]) for i in range(0,nmax,navg)]
-    
+
 
 
 #Open the Hitran file for the molecule in question,
@@ -477,7 +478,7 @@ def smooth(wAvg,data):
 #        in Earth's atmosphere. When loading minor isotopologues,
 #        it is important to undo this weighting, so that the
 #        correct abundance weighting for the actual mixture of
-#        interest can be computed. 
+#        interest can be computed.
 #**DKOLL:
 #        modified to speed up long line lists.
 #        skip lines until you're close to your spectral region of interest.
@@ -537,7 +538,7 @@ def loadSpectralLines(molName,minWave=None,maxWave=None):
             #practice for IR
             #
             #**ToDo: Put in correct molecular weight for the
-            #        isotope in question.  
+            #        isotope in question.
             S = .1*(phys.N_avogadro/molecules[molName][1])*S
             gamAir = string.atof(get(line,airWidth))
             gamSelf = string.atof(get(line,selfWidth))
@@ -589,7 +590,7 @@ def getKappa_HITRAN(waveGrid,wave0,wave1,delta_wave,molecule_name,\
     T = float(temp)
 
     loadSpectralLines(molName,minWave=wave0,maxWave=wave1)
-    
+
 #-->Decide whether you want to compute air-broadened
 #or self-broadened absorption. The plots of self/air
 #ratio in the book were done by running this script for
@@ -614,7 +615,7 @@ def getKappa_HITRAN(waveGrid,wave0,wave1,delta_wave,molecule_name,\
 #This is a very crude implementation of the far-tail cutoff.
 #I have been using 1000 widths as my standard value.
     nWidths = lineWid
-    
+
     if cutoff_option=="relative":
         absGrid = computeAbsorption(waveGrid,getGamma,p,T,dWave,nWidths)
     elif cutoff_option=="fixed":

--- a/pyrads/ClimateGraphics.py
+++ b/pyrads/ClimateGraphics.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 #----------Section 3: Plotting utilities-------------------------------
 #These need to be localized, for systems that don't support Ngl
 #

--- a/pyrads/ClimateGraphics.py
+++ b/pyrads/ClimateGraphics.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 #----------Section 3: Plotting utilities-------------------------------
 #These need to be localized, for systems that don't support Ngl
 #
@@ -20,18 +21,18 @@
 
 #Note: On some older installations, Ngl has to
 #be imported as PyNGL instead of Ngl.  If there
-#is a trouble with the import, fiddle with that. 
+#is a trouble with the import, fiddle with that.
 try:
     import Ngl
 except:
     try:
         import PyNGL as Ngl
     except:
-        print "PyNGL was not found on your system."
-        print "You will not be able to use graphics functions."
-        print "PyNGL is available for Mac OSX,Linux and Windows/CygWin"
-        print "Alternately, modify the module ClimateGraphics.py"
-        print "to use some other graphics driver"
+        print( "PyNGL was not found on your system.")
+        print( "You will not be able to use graphics functions.")
+        print( "PyNGL is available for Mac OSX,Linux and Windows/CygWin")
+        print( "Alternately, modify the module ClimateGraphics.py")
+        print( "to use some other graphics driver")
         raise('Graphics Import Error')
 
 #A dummy class useful for passing parameters.
@@ -71,7 +72,7 @@ class plotObj:
         Ngl.draw(self.plot)
         Ngl.change_workstation(self.plot,self.workstation)
         Ngl.destroy(weps)
-        
+
 #ToDo:
 #       *Implement use of missing data coding.
 #       *Provide some way to re-use window (e.g. by
@@ -107,12 +108,12 @@ def plot(c):
     #Plot title
     r.tiMainString = c.PlotTitle
     #Axis labels (ToDo: add defaults)
-    #X and Y axis labels    
+    #X and Y axis labels
     r.tiXAxisString = c.Xlabel
     r.tiYAxisString = c.Ylabel
     if c.switchXY:
         r.tiXAxisString,r.tiYAxisString = r.tiYAxisString,r.tiXAxisString
-        
+
     #  Legends, for multicurve plot
     legends = []
     for id in c.listVariables():
@@ -179,7 +180,7 @@ def contour(A,**kwargs):
         r.sfYArray = kwargs['y']
     #
     # Now create the plot
-    
+
     rw = Dummy()
     #Set the color map
     if 'colors' in kwargs.keys():
@@ -190,8 +191,8 @@ def contour(A,**kwargs):
             rw.wkColorMap = kwargs['colors']
     else:
         #Default rainbow color table
-        rw.wkColorMap = "temp1" 
-    
+        rw.wkColorMap = "temp1"
+
     w = Ngl.open_wks('x11','Climate Workbook',rw)
     r.nglDraw = False
     r.nglFrame = False

--- a/pyrads/ClimateGraphicsMPL.py
+++ b/pyrads/ClimateGraphicsMPL.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 #----------Section 3: Plotting utilities-------------------------------
 #Graphics interface customized for MatPlotLib
 #     --------------->UNDER DEVELOPMENT
@@ -20,7 +21,7 @@
 #-----------------------------------------------------------------------
 
 
-#Try to import matplotlib plotting routines 
+#Try to import matplotlib plotting routines
 try:
     import matplotlib as mpl
     #Configure the backend so things work properly
@@ -36,9 +37,9 @@ try:
     #
     import pylab as pl
 except:
-    print 'matplotlib not found on your system'
-    print 'You can still run the courseware, but'
-    print 'will not be able to plot from inside Python'
+    print( 'matplotlib not found on your system')
+    print( 'You can still run the courseware, but')
+    print( 'will not be able to plot from inside Python')
 
 #A dummy class useful for passing parameters.
 #Just make an instance, then add new members
@@ -70,12 +71,12 @@ class plotObj:
         self.WorkstationResources = WorkstationResources
     #Deletes a plot window
     def delete(self):
-        print "In MatPlotLib just click the goaway button to dispose a plot"
+        print( "In MatPlotLib just click the goaway button to dispose a plot")
     def save(self,filename = 'plot'):
         #**ToDo: Can we implement non-interactive save in MPL?
-        print "In MatPlotLib save plots interactively using the file button"
-        print " in the plot window"
-        
+        print( "In MatPlotLib save plots interactively using the file button")
+        print( " in the plot window")
+
 #ToDo:
 #       *Implement use of missing data coding.
 #       *Provide some way to re-use window (e.g. by
@@ -96,7 +97,7 @@ class plotObj:
 
 #List of line colors and line styles to use
 lineColors = ['b','g','r','c','m','y','k']
-lineStyles = ['-','--','-.',':'] 
+lineStyles = ['-','--','-.',':']
 lineThickness = [2,3,4]
 plotSymbols = ['.','o','v','<','s','*','+','x']
 def plot(c):
@@ -120,7 +121,7 @@ def plot(c):
     #r.tiMainString = c.PlotTitle
     pl.title(c.PlotTitle)
     #Axis labels (ToDo: add defaults)
-    #X and Y axis labels    
+    #X and Y axis labels
     #r.tiXAxisString = c.Xlabel
     #r.tiYAxisString = c.Ylabel
     if c.switchXY:
@@ -129,7 +130,7 @@ def plot(c):
     else:
         pl.xlabel(c.Xlabel)
         pl.ylabel(c.Ylabel)
-        
+
     #  Legends, for multicurve plot
     legends = []
     for id in c.listVariables():
@@ -154,7 +155,7 @@ def plot(c):
                 #r.xyMarkLineModes.append('Markers')
                 color = lineColors[count%len(lineColors)]
                 symbol = plotSymbols[count%len(plotSymbols)]
-                formatList.append(color+symbol) 
+                formatList.append(color+symbol)
             else:
                 color = lineColors[count%len(lineColors)]
                 style = lineStyles[count%len(lineStyles)]
@@ -226,7 +227,7 @@ def contour(A,**kwargs):
 ##        r = kwargs['resource']
 ##    else:
 ##        r = Dummy()
-##    
+##
 ##    rw = Dummy()
 ##    #Set the color map
 ##    if 'colors' in kwargs.keys():
@@ -237,4 +238,4 @@ def contour(A,**kwargs):
 ##            rw.wkColorMap = kwargs['colors']
 ##    else:
 ##        #Default rainbow color table
-##        rw.wkColorMap = "temp1" 
+##        rw.wkColorMap = "temp1"

--- a/pyrads/ClimateGraphicsMPL.py
+++ b/pyrads/ClimateGraphicsMPL.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 #----------Section 3: Plotting utilities-------------------------------
 #Graphics interface customized for MatPlotLib
 #     --------------->UNDER DEVELOPMENT

--- a/pyrads/ClimateUtilities.py
+++ b/pyrads/ClimateUtilities.py
@@ -231,8 +231,8 @@ class Curve:
 
 
 
-from string import atof
-
+#from string import atof
+#  deprecated in Python 2.7, gone in Python 3... just use float()
 
 # Scans a list of lines, locates data lines
 # and size, splits of column headers and
@@ -268,7 +268,8 @@ def scan(buff,inHeader=None,delimiter = None):
         line = buff[startDataLine].split(delimiter)
     #
     try:
-        atof(line[0])
+        #atof(line[0])
+        float(line[0])
     except:
         header = line
     if len(header) == 0:
@@ -291,7 +292,8 @@ def scan(buff,inHeader=None,delimiter = None):
             items = line.split(delimiter)
         try:
          for i in range(len(varlist)):
-            varlist[i].append(atof(items[i]))
+            #varlist[i].append(atof(items[i]))
+            varlist[i].append(float(items[i]))
         except:
             print( items)
     vardict = {}

--- a/pyrads/ClimateUtilities.py
+++ b/pyrads/ClimateUtilities.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 ### THIS SCRIPT IS TAKEN FROM THE COURSEWARE OF
 ###  Pierrehumbert, 2010, Principles of Planetary Climate
 ###
@@ -55,12 +56,12 @@ except:
     try:
         import Numeric
         import Numeric as numpy    #For frontwards compatibility
-        numpy.float = numpy.Float  #For frontwards compatibility 
-        print "numpy not found. Using Numeric instead"
-        print "Everything should still work, but consider upgrading to numpy"
+        numpy.float = numpy.Float  #For frontwards compatibility
+        print( "numpy not found. Using Numeric instead")
+        print( "Everything should still work, but consider upgrading to numpy")
     except:
-        print "Neither numpy nor Numeric found."
-        print "Please install numpy (preferred) or Numeric."
+        print( "Neither numpy nor Numeric found.")
+        print( "Please install numpy (preferred) or Numeric.")
 
 #-----------------------------------------------------
 #Import graphics utilities
@@ -87,13 +88,13 @@ except:
     try:
         from ClimateGraphicsMPL import * #Try importing MatPlotLib
     except:
-        print "  "
-        print "Graphics not implemented."
-        print "Plot routines will not produce graphs."
-        print "Instead, you can save results from a Curve"
-        print "object c into a text file using c.dump(<FILENAME>)"
-        print "and then plot the data using the graphics program"
-        print "of your choice."
+        print( "  ")
+        print( "Graphics not implemented.")
+        print( "Plot routines will not produce graphs.")
+        print( "Instead, you can save results from a Curve")
+        print( "object c into a text file using c.dump(<FILENAME>)")
+        print( "and then plot the data using the graphics program")
+        print( "of your choice.")
         from DummyGraphics import *
 
 #Section 1: -----Data handling utilities-------------------------------
@@ -135,7 +136,7 @@ class Curve:
     #
     #Install a new curve in the data set, optionally with a variable name and label
     #Any 1D indexable object can be installed here:a Numeric array, a Masked Array,
-    #a Masked Variable (as in cdms) or an ordinary list. 
+    #a Masked Variable (as in cdms) or an ordinary list.
     def addCurve(self,data,id = '',label = ''):
         self.NumCurves += 1
         if len(id) == 0:
@@ -158,7 +159,7 @@ class Curve:
         try:
             n = len(data[:])
         except:
-            print "Object on RHS is not indexable"
+            print( "Object on RHS is not indexable")
             return None
         #Transform data from list to a Numeric array here
         if type(data) == type([]):
@@ -167,7 +168,7 @@ class Curve:
             self.data[id] = data
         else:
             self.addCurve(data,id)
-    
+
     #Method to return Numeric abcissa array for plotting.
     def X(self):
         #Use of cross section lets us get data from any indexed object
@@ -176,12 +177,12 @@ class Curve:
         #explicitly for a _data component.
         #
         #This method is used mainly for generating arrays used in plotting,
-        #and should be streamlined at some point. 
+        #and should be streamlined at some point.
         temp = self.data[self.Xid][:]
         if hasattr(temp,'_data'):
             temp = temp._data[:]
         return Numeric.array(temp,Numeric.Float)
-    
+
     #Method to return Numeric ordinate array for plotting
     def Y(self):
         #Use of cross section lets us get data from any indexed object
@@ -225,11 +226,11 @@ class Curve:
         for dataName in dataList:
             c.addCurve(self[dataName],dataName)
         return c
-            
-            
-            
-            
-    
+
+
+
+
+
 from string import atof
 
 
@@ -255,7 +256,7 @@ def scan(buff,inHeader=None,delimiter = None):
     buff = clean(buff)
     #
     #Now look for patterns that indicate data lines
-    #     
+    #
     startDataLine,endDataLine = findData(buff)
     # Found number of items. Now read in the data
     #
@@ -292,7 +293,7 @@ def scan(buff,inHeader=None,delimiter = None):
          for i in range(len(varlist)):
             varlist[i].append(atof(items[i]))
         except:
-            print items
+            print( items)
     vardict = {}
     for name in header:
         vardict[name] = varlist[header.index(name)]
@@ -344,9 +345,9 @@ def readTable(filename,inHeader = None,delimiter = None):
         c.addCurve(data[key],key)
     return c
 
-    
-    
-    
+
+
+
 #==============================================
 #---Section 2: Math utilities-------------------------------------------
 #==============================================
@@ -366,7 +367,7 @@ class Dummy:
 def polint(xa,ya,x):
     n = len(xa)
     if not (len(xa) == len(ya)):
-            print "Input x and y arrays must be same length"
+            print( "Input x and y arrays must be same length")
             return "Error"
         #Set up auxiliary arrays
     c = Numeric.zeros(n,Numeric.Float)
@@ -382,7 +383,7 @@ def polint(xa,ya,x):
                 diff = difft
                 ns = i
     y=ya[ns]
-    for m in range(1,n): 
+    for m in range(1,n):
         for i in range(n-m):
             ho=xa[i]-x
             hp=xa[i+m]-x
@@ -395,7 +396,7 @@ def polint(xa,ya,x):
             ns -= 1
             dy = d[ns]
         y += dy
-        #You can also return dy as an error estimate. Here 
+        #You can also return dy as an error estimate. Here
         #to keep things simple, we just return y.
     return y
 
@@ -514,7 +515,7 @@ class romberg:
             self.f = f1
         else:
             name = f.func_name
-            print 'Error: %s has wrong number of arguments'%name
+            print( 'Error: %s has wrong number of arguments'%name)
         #-----------------------------------------------------
         #
         #We keep lists of all our results, for doing
@@ -547,14 +548,14 @@ class romberg:
         self.nList.append(self.nstart)
         self.integralList.append(self.trap.integral)
         #
-        #Refine initial evaluation until 
+        #Refine initial evaluation until
         oldval = self.refine()
         newval = self.refine()
         while abs(oldval-newval)>tolerance:
             oldval,newval = newval,self.refine()
         return newval
-        
-        
+
+
 
 #-------Runge-Kutta ODE integrator
 #**ToDo:
@@ -582,13 +583,13 @@ class romberg:
 #
 #      * Make the integrator object callable. The call can return
 #        a list of results for all the intermediate steps, or optionally
-#        just the final value.  
+#        just the final value.
 class integrator:
   '''
   Runge-Kutta integrator, for 1D or multidimensional problems
-  
+
   Usage:
-  
+
   First you define a function that returns the
   derivative(s), given the independent and dependent
   variables as arguments. The independent variable (think
@@ -600,15 +601,15 @@ class integrator:
   arithmetic operations. It will not work with plain Python lists.
   The derivative function should return an array of derivatives, in
   the multidimensional case. The derivative function can have any name.
-  
+
   The derivative function can optionally have a third argument, to provide
   for passing parameters (e.g. the radius of the Earth) to the
   function.  The "parameter" argument, if present, can be any Python
   entity whatsoever. If you need to pass multiple constants, or
   even tables or functions, to your derivative function, you can
   stuff them all into a list or a Python object.
-  
-  
+
+
   Example:
   In the 1D case, to solve the equation
                   dz/dt = -a*t*t/(1.+z*z)
@@ -616,26 +617,26 @@ class integrator:
   independent variable, your derivative function would  be
     def g(t,z):
        return -a*t*t/(1.+z*z)
-  
+
   treating the parameter a as a global, or perhaps
     def g(t,z,params):
        return -params.a*t*t/(params.b+z*z)
-  
+
   while in a 2D case, your function might look like:
     def g(t,z):
       return Numeric.array([-z[1],z[0]])
-  
+
   or perhaps something like:
     def g(t,z):
       return t*Numeric.sin(z)
-  
+
   or even
     def g(t,z,params):
       return Numeric.matrixmultiply(params(t),z)
-      
+
   where params(t) in this case is a function returning
   a Numeric square matrix of the right dimension to multiply z.
-  
+
   BIG WARNING:  Note that all the examples which return a
   Numeric array return a NEW INSTANCE (i.e. copy) of an
   array.  If you try to set up a global array and re-use
@@ -658,39 +659,39 @@ class integrator:
       return Numeric.array([z[1],-z[0]])
   Try this one. It should work properly now. Note that any arithmetic
   performed on Numeric array objects returns a new instance of an Array
-  object. Hence, a function definition like 
+  object. Hence, a function definition like
     def g(t,z):
       return t*z*z+1.
   will work fine.
-  
-  Once you have defined the derivitave function, 
+
+  Once you have defined the derivitave function,
   you then proceed as follows.
-  
+
   First c reate an integrator instance:
     int_g = integrator(g,0.,start,.01)
-  
+
   where "0." in the argument list is the initial value
   for the independent variable, "start" is the initial
   value for the dependent variable, and ".01" is the
   step size. You then use the integrator as follows:
-  
+
     int_g.setParams(myParams)
     while int_g.x < 500:
-       print int_g.next()
-  
+       print( int_g.next())
+
   The call to setParams is optional. Just use it if your
   function makes use of a parameter object. The next() method
   accepts the integration increment (e.g. dx) as an optional
   argument. This is in case you want to change the step size,
   which you can do at any time.  The integrator continues
   using the most recent step size it knows.
-  
+
   Each call to int_g.next returns a list, the first of whose
   elements is the new value of the independent variable, and
   the second of whose elements is a scalar or array giving
   the value of the dependent variable(s) at the incremented
-  independent variable. 
-  
+  independent variable.
+
   '''
   def __init__(self, derivs,xstart,ystart,dx=None):
     self.derivsin = derivs
@@ -710,13 +711,13 @@ class integrator:
         self.derivs = derivs1
     else:
         name = derivs.func_name
-        print 'Error: %s has wrong number of arguments'%name
+        print('Error: %s has wrong number of arguments'%name)
     #
     #
     self.x = xstart
     #The next statement is a cheap trick to initialize
     #y with a copy of ystart, which works whether y is
-    #a regular scalar or a Numeric array.  
+    #a regular scalar or a Numeric array.
     self.y = 0.+ ystart
     self.dx = dx #Can instead be set with the first call to next()
     self.params = None
@@ -751,12 +752,12 @@ class integrator:
 
 
 
-#**ToDo:  
+#**ToDo:
 #
 #         Store the previous solution for use as the next guess(?)
 #
 #        Handle arithmetic exceptions in the iteration loop
-#  
+#
 class newtSolve:
     '''
     Newton method solver for function of 1 variable
@@ -781,7 +782,7 @@ class newtSolve:
     the derivative function by invoking solver.deriv(x)
     As for f, fp can be optionally defined with a parameter
     argument if you need it. The same parameter object is
-    passed to f and fp. 
+    passed to f and fp.
 
     Use solver.setParams(value) to set the parameter object
     Alternately, the parameter argument can be passed as
@@ -804,7 +805,7 @@ class newtSolve:
               return x*x - 1.
           roots = newtSolve(g)
           roots(2.)
-         
+
          Example 2, Function with parameters:
           def g(x,constants):
               return constants.a*x*x - constants.b
@@ -829,7 +830,7 @@ class newtSolve:
           roots = newtSolve(g)
           guesses = roots.scan([-2.,2.],100)
           for guess in guesses:
-              print roots(guess)
+              print( roots(guess))
     '''
     def __init__(self,f,fprime = None):
         self.fin = f
@@ -844,12 +845,12 @@ class newtSolve:
             self.f = f1
         else:
             name = f.func_name
-            print 'Error: %s has wrong number of arguments'%name
+            print( 'Error: %s has wrong number of arguments'%name)
         self.eps = 1.e-6
         def deriv(x,params):
             return (self.f(x+self.eps,params)- self.f(x-self.eps,params))/(2.*self.eps)
         if fprime == None:
-            self.deriv = deriv 
+            self.deriv = deriv
         else:
             #A derivative function was explicitly specified
             #Check if it has a parameter argument
@@ -863,7 +864,7 @@ class newtSolve:
                 self.deriv = fprime1
             else:
                 name = fprime.func_name
-                print 'Error: %s has wrong number of arguments'%name
+                print( 'Error: %s has wrong number of arguments'%name)
         self.tolerance = 1.e-6
         self.nmax = 100
         self.params = None
@@ -903,10 +904,3 @@ class newtSolve:
                 guessList.append(x)
             flast = fnow
         return guessList
-
-
-
-
-
-    
-         

--- a/pyrads/ClimateUtilities.py
+++ b/pyrads/ClimateUtilities.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 ### THIS SCRIPT IS TAKEN FROM THE COURSEWARE OF
 ###  Pierrehumbert, 2010, Principles of Planetary Climate
 ###
@@ -77,7 +77,7 @@ except:
 #------------------------------------------------------
 
 try:
-    from ClimateGraphicsMPL import * #Try importing MatPlotLib
+    from .ClimateGraphicsMPL import * #Try importing MatPlotLib
 #    from ClimateGraphics import * #Try importing Ngl driver
 except:
     # If Ngl not found, try importing the graphics interface
@@ -86,7 +86,7 @@ except:
     #or just do "from ClimateGraphicsMPL import *" after you
     #import ClimateUtilities .
     try:
-        from ClimateGraphicsMPL import * #Try importing MatPlotLib
+        from .ClimateGraphicsMPL import * #Try importing MatPlotLib
     except:
         print( "  ")
         print( "Graphics not implemented.")
@@ -95,7 +95,7 @@ except:
         print( "object c into a text file using c.dump(<FILENAME>)")
         print( "and then plot the data using the graphics program")
         print( "of your choice.")
-        from DummyGraphics import *
+        from .DummyGraphics import *
 
 #Section 1: -----Data handling utilities-------------------------------
 

--- a/pyrads/DummyGraphics.py
+++ b/pyrads/DummyGraphics.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 #----------Section 3: Plotting utilities-------------------------------
 #This is a dummy graphics routine, to import if a graphics driver
 #is not found. It is the fallback import if the import of ClimateGraphics

--- a/pyrads/DummyGraphics.py
+++ b/pyrads/DummyGraphics.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 #----------Section 3: Plotting utilities-------------------------------
 #This is a dummy graphics routine, to import if a graphics driver
 #is not found. It is the fallback import if the import of ClimateGraphics
@@ -41,10 +42,10 @@ class plotObj:
     def save(self,filename = 'plot'):
         #Saves a plot to a file
         pass
-        
+
 #Makes a line pot from a Curve object
 def plot(c):
-    print "Plotting not implemented"
+    print( "Plotting not implemented")
     #Set axis options according to information
     #in the curve object c.
     #
@@ -61,9 +62,9 @@ def plot(c):
     #
     #Set thePlot title
     #c.PlotTitle:
-    #   String containing the plot title     
+    #   String containing the plot title
     #Axis labels
-    #X and Y axis labels   
+    #X and Y axis labels
     #c.Xlabel:
     #   String containing the X axis label
     #c.Ylabel:
@@ -73,7 +74,7 @@ def plot(c):
     if c.switchXY:
         pass
         #If True, exchang the axes
-        
+
     #  Legends, for multicurve plot
     legends = []
     for id in c.listVariables():
@@ -130,7 +131,7 @@ def plot(c):
 # the y scale to be the array (or list) lon, we would call
 # contour as contour(A,x=lat,y=lon).
 def contour(A,**kwargs):
-    print "Plotting not implemented"
+    print( "Plotting not implemented")
     #The following allows an expert user to pass
     # options directly to the plotter.
     if 'resource' in kwargs.keys():
@@ -141,13 +142,13 @@ def contour(A,**kwargs):
     r.cnFillOn = True #Use color fill
 
     if 'x' in kwargs.keys():
-        #Set the X array for the contour plot        
+        #Set the X array for the contour plot
         XArray = kwargs['x']
     if 'y' in kwargs.keys():
         #Set the Y array for the contour plot
         YArray = kwargs['y']
     #
-    # Now create the plot    
+    # Now create the plot
     rw = Dummy()
     #Set the color map
     if 'colors' in kwargs.keys():
@@ -159,7 +160,7 @@ def contour(A,**kwargs):
             rw.wkColorMap = kwargs['colors']
     else:
         #Default rainbow color table
-        rw.wkColorMap = "temp1" 
+        rw.wkColorMap = "temp1"
 
     #Open/initialize a plot window
     w = None

--- a/pyrads/Get_Fluxes.py
+++ b/pyrads/Get_Fluxes.py
@@ -1,8 +1,8 @@
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 import numpy as np
 import phys
 
-from Planck import Planck_n
+from .Planck import Planck_n
 
 # Here: choose integrator
 from scipy.integrate import trapz as numint

--- a/pyrads/Get_Fluxes.py
+++ b/pyrads/Get_Fluxes.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 import numpy as np
-import phys
+from . import phys
 
 from .Planck import Planck_n
 

--- a/pyrads/Get_Fluxes.py
+++ b/pyrads/Get_Fluxes.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import numpy as np
 import phys
 
@@ -51,4 +52,3 @@ def Fplus_alternative(i,data):
 
 def integrate_over_tau(i,data,integrand):
     return -1.* numint( integrand[i:,:],x=trans(i,slice(i,None),data.tau), axis=0)
-

--- a/pyrads/OpticalThickness.py
+++ b/pyrads/OpticalThickness.py
@@ -1,9 +1,10 @@
 '''
 ***********************************************************
-This script computes absorption coefficients and 
+This script computes absorption coefficients and
 optical thicknesses.
 ***********************************************************
 '''
+from __future__ import division, print_function
 import numpy as np
 from Absorption_Crosssections_HITRAN2016 import getKappa_HITRAN
 import Absorption_Continuum_MTCKD
@@ -13,14 +14,14 @@ from scipy.integrate import cumtrapz
 from Thermodynamics import convert_molar_to_mass_ratio
 
 # ---
-## 
+##
 def compute_tau_H2ON2(p,T,q,grid,params,RH=1.):
 
     kappa = np.zeros( (grid.Np,grid.Nn) )
     for pres,temp,q_H2O in zip(p,T,q):
         p_H2O = RH * params.esat(temp)  # ...
 
-        print "compute kappa at p,T = ",pres,temp
+        print( "compute kappa at p,T = ",pres,temp)
         kappaH2O = getKappa_HITRAN(grid.n,grid.n0,grid.n1,grid.dn, \
                                        "H2O",press=pres,press_self=p_H2O, \
                                        temp=temp,broadening="air", lineWid=25., \
@@ -33,12 +34,12 @@ def compute_tau_H2ON2(p,T,q,grid,params,RH=1.):
                             exe_file=Absorption_Continuum_MTCKD.mtckd_exe_H2O_N2)
 
         kappa[ p==pres,: ] = kappaH2O*q_H2O + kappaH2O_cont*q_H2O  # save
-    print "done! \n"
+    print( "done! \n")
 
     # Integrate to get optical thickness:
     p2d = np.tile( p,(grid.Nn,1) ).T
     tau = 1./(params.g*params.cosThetaBar) * cumtrapz( kappa,x=p2d,initial=0.,axis=0 )
-    
+
     return tau
 
 
@@ -54,7 +55,7 @@ def compute_tau_H2ON2_CO2dilute(p,T,q,ppv_CO2,grid,params,RH=1.):
         R_mean = q_H2O*params.Rv + (1.-q_H2O)*params.R
         q_CO2 = convert_molar_to_mass_ratio(ppv_CO2,params.R_CO2,R_mean)
 
-        print "compute kappa at p,T = ",pres,temp
+        print( "compute kappa at p,T = ",pres,temp)
         kappaH2O = getKappa_HITRAN(grid.n,grid.n0,grid.n1,grid.dn, \
                                        "H2O",press=pres,press_self=p_H2O, \
                                        temp=temp,broadening="air", lineWid=25., \
@@ -72,12 +73,12 @@ def compute_tau_H2ON2_CO2dilute(p,T,q,ppv_CO2,grid,params,RH=1.):
                             exe_file=Absorption_Continuum_MTCKD.mtckd_exe_H2O_N2)
 
         kappa[ p==pres,: ] = kappaH2O*q_H2O + kappaH2O_cont*q_H2O + kappaCO2*q_CO2  # save
-    print "done! \n"
+    print( "done! \n")
 
     # Integrate to get optical thickness:
     p2d = np.tile( p,(grid.Nn,1) ).T
     tau = 1./(params.g*params.cosThetaBar) * cumtrapz( kappa,x=p2d,initial=0.,axis=0 )
-    
+
     return tau
 
 
@@ -90,17 +91,16 @@ def compute_tau_dryCO2(p,T,q,ppv_CO2,grid,params):
         R_mean = params.R
         q_CO2 = convert_molar_to_mass_ratio(ppv_CO2,params.R_CO2,R_mean)
 
-        print "compute kappa at p,T = ",pres,temp
+        print( "compute kappa at p,T = ",pres,temp)
         kappaCO2 = getKappa_HITRAN(grid.n,grid.n0,grid.n1,grid.dn, \
                                        "CO2",press=pres,press_self=0., \
                                        temp=temp,broadening="air", lineWid=25., \
                                        cutoff_option="fixed",remove_plinth=False)  # don't take out plinth!
         kappa[ p==pres,: ] = kappaCO2*q_CO2     # save
-    print "done! \n"
+    print( "done! \n")
 
     # Integrate to get optical thickness:
     p2d = np.tile( p,(grid.Nn,1) ).T
     tau = 1./(params.g*params.cosThetaBar) * cumtrapz( kappa,x=p2d,initial=0.,axis=0 )
-    
-    return tau
 
+    return tau

--- a/pyrads/OpticalThickness.py
+++ b/pyrads/OpticalThickness.py
@@ -4,14 +4,14 @@ This script computes absorption coefficients and
 optical thicknesses.
 ***********************************************************
 '''
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 import numpy as np
-from Absorption_Crosssections_HITRAN2016 import getKappa_HITRAN
-import Absorption_Continuum_MTCKD
-from Absorption_Continuum_MTCKD import get_H2OContinuum
+from .Absorption_Crosssections_HITRAN2016 import getKappa_HITRAN
+from . import Absorption_Continuum_MTCKD
+from .Absorption_Continuum_MTCKD import get_H2OContinuum
 from scipy.integrate import cumtrapz
 
-from Thermodynamics import convert_molar_to_mass_ratio
+from .Thermodynamics import convert_molar_to_mass_ratio
 
 # ---
 ##

--- a/pyrads/Planck.py
+++ b/pyrads/Planck.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 import numpy as np
 import phys
 

--- a/pyrads/Planck.py
+++ b/pyrads/Planck.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 import numpy as np
 import phys
 
@@ -29,7 +30,7 @@ def Planck_n(n,T,unit="cm^-1"):
         n = n*100.
         k = 100.
     else:
-        print "(Planck_n) Error: unit not recognized!"
+        print( "(Planck_n) Error: unit not recognized!")
     return k*phys.c*Planck_nu(n*phys.c,T)
 
 
@@ -57,7 +58,7 @@ def Tbrightness_n(n,I,unit="cm^-1"):
         n = n*100.
         k = 100.
     else:
-        print "(Planck_n) Error: unit not recognized!"
+        print( "(Planck_n) Error: unit not recognized!")
 
     return Tbrightness_nu(n*phys.c, I/(k*phys.c))
 
@@ -78,6 +79,6 @@ def dPlanckdT_n(n,T,unit="cm^-1"):
     elif unit=="cm^-1":
         k = 100.
     else:
-        print "(Planck_n) Error: unit not recognized!"
+        print( "(Planck_n) Error: unit not recognized!")
 
     return (k*phys.c) * dPlanckdT_nu( phys.c*n*k ,T)

--- a/pyrads/Planck.py
+++ b/pyrads/Planck.py
@@ -1,6 +1,6 @@
 from __future__ import division, print_function, absolute_import
 import numpy as np
-import phys
+from . import phys
 
 ###
 # Planck function (of frequency)

--- a/pyrads/SetupGrids.py
+++ b/pyrads/SetupGrids.py
@@ -3,10 +3,10 @@
 This script setups the vertical and spectral grids.
 ***********************************************************
 '''
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 import numpy as np
-import VerticalStructure
-import Thermodynamics
+from . import VerticalStructure
+from . import Thermodynamics
 
 # ---
 ## Helpers

--- a/pyrads/SetupGrids.py
+++ b/pyrads/SetupGrids.py
@@ -3,6 +3,7 @@
 This script setups the vertical and spectral grids.
 ***********************************************************
 '''
+from __future__ import division, print_function
 import numpy as np
 import VerticalStructure
 import Thermodynamics
@@ -32,7 +33,7 @@ def make_grid( Ts,Tstrat,N_press,wavenr_min,wavenr_max,dwavenr,params, \
     grid.n = np.arange( grid.n0, grid.n1, grid.dn )  # 1d
     grid.wave = np.tile( grid.n,(grid.Np,1) )         # 2d
     grid.Nn = len(grid.n)
-    
+
     # start filling arrays: compute p,T,q profiles
     #  -> careful about starting pressure!
     #  -> note: stratosphere only used for a full moist adiabat!
@@ -47,7 +48,6 @@ def make_grid( Ts,Tstrat,N_press,wavenr_min,wavenr_max,dwavenr,params, \
         grid.T = VerticalStructure.get_TofP_SingleCompAdiabat(grid.p,params)
         grid.q = grid.T * 0. + 1.
     else:
-        print "(setupgrids) error: adiabat choice=",adiabat, " -> not recognized!  *****"
+        print( "(setupgrids) error: adiabat choice=",adiabat, " -> not recognized!  *****")
 
     return grid
-

--- a/pyrads/Thermodynamics.py
+++ b/pyrads/Thermodynamics.py
@@ -1,6 +1,7 @@
 '''
 Thermodynamic helper functions.
 '''
+from __future__ import division, print_function
 import numpy as np
 
 
@@ -23,7 +24,7 @@ def get_qsat(T,p_tot,params):
 # ---
 # Input: T and *total* pressure. (Partial dry pressure is inferred.)
 # Output: specific humidity.
-# 
+#
 # --> Valid for any value of RH! If RH=1, reduces to get_qsat.
 def get_q(T,p_tot,params,RH=1.):
     eps = params.R/params.Rv
@@ -36,14 +37,14 @@ def get_q(T,p_tot,params,RH=1.):
 # ---
 # Input: T and *total* pressure.
 # Output: mass mixing ratio r := rho_H2O / rho_dry = m_H2O*p_H2O / (m_dry * p_dry)
-# 
+#
 # NOTE: this is NOT the volume/number mixing ratio !
 #       for that simply use n_H2O/n_dry = p_H2O/p_dry
 def get_rsat(T,p_tot,params):
     eps = params.R/params.Rv
     e_sat = params.esat(T)
     p_dry = p_tot - e_sat
-    r_sat = eps * e_sat / p_dry    
+    r_sat = eps * e_sat / p_dry
     return r_sat
 
 
@@ -55,7 +56,7 @@ def get_rsat(T,p_tot,params):
 #         molar concentration   eta := n_i / (n_i + n_rest)
 # Output: abundance of gas, by mass
 #         mass mixing ratio   q := rho_i / (rho_i + rho_rest)
-# 
+#
 # where rho_i is (mass) density, and n_i is number density.
 #
 # Formula is (see, e.g., PoPC p.86-87):
@@ -72,4 +73,3 @@ def convert_molar_to_mass_ratio(molar_i,R_i,R_air):
     R_mean = 1./(molar_i/R_i + molar_air/R_air)
     q_i = molar_i * R_mean/R_i
     return q_i
-

--- a/pyrads/Thermodynamics.py
+++ b/pyrads/Thermodynamics.py
@@ -1,7 +1,7 @@
 '''
 Thermodynamic helper functions.
 '''
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 import numpy as np
 
 

--- a/pyrads/VerticalStructure.py
+++ b/pyrads/VerticalStructure.py
@@ -4,6 +4,7 @@ This script provides a number of functions to compute
 vertical temperature,humidity structure.
 ***********************************************************
 '''
+from __future__ import division, print_function
 
 import numpy as np
 import scipy
@@ -34,18 +35,18 @@ def get_Tq_moist(p,Ts,ps,params,RH=1.,Tstrat=None):
     if Tstrat is not None and np.any(T_adiabat < Tstrat):
         # caution: only implements stratosphere if T<Tstrat anywhere
         # this can fail at crappy vertical resolution!
-        
+
         mask = T_adiabat < Tstrat
         T = T_adiabat
         T[mask] = Tstrat
-            
+
         # pick highest pressure level in strat, assume q is uniform at that value
         q = q_adiabat
         q[mask] = q_adiabat[p==(p[mask].max())]
     else:
         T = T_adiabat
         q = q_adiabat
-        
+
     return T,q
 
 
@@ -64,7 +65,7 @@ def get_TofP_MoistAdiabat(p,Ts,ps_in,params):
 
     #ps = ps_in + esat(Ts)  # here: assume ps_in is dry pressure only
     ps = ps_in
-    
+
     # (integrate dlogT/dlog(p/ps)): based on eqn. 12 in Ding & Pierrehumbert (2016)
     def slope(logT,logpps):
         T = np.exp(logT)
@@ -96,7 +97,7 @@ def get_TofP_MoistAdiabat(p,Ts,ps_in,params):
         return np.exp(logInt[1:])  # don't return initial value...
     else:
         return np.exp(logInt[-1])  # don't return initial value...
-    
+
 
 # analytical dry adiabat, T=T(p)
 def get_TofP_DryAdiabat(p,Ts,ps,params):
@@ -105,6 +106,3 @@ def get_TofP_DryAdiabat(p,Ts,ps,params):
 # analytical single-component moist adiabat, T=T(p)
 def get_TofP_SingleCompAdiabat(p,params):
     return params.satvap_T0 / (1. - params.Rv*params.satvap_T0/params.Lvap * np.log(p/params.satvap_e0) )
-
-
-

--- a/pyrads/VerticalStructure.py
+++ b/pyrads/VerticalStructure.py
@@ -4,12 +4,12 @@ This script provides a number of functions to compute
 vertical temperature,humidity structure.
 ***********************************************************
 '''
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 
 import numpy as np
 import scipy
 from scipy.optimize import fsolve  # [!]
-from Thermodynamics import get_qsat,get_q,get_satvps
+from .Thermodynamics import get_qsat,get_q,get_satvps
 
 
 # Returns T-p, q-p profiles, assuming a moist adiabat.

--- a/pyrads/__init__.py
+++ b/pyrads/__init__.py
@@ -1,13 +1,14 @@
-import Absorption_Continuum
-import Absorption_Continuum_MTCKD
-import Absorption_Crosssections_HITRAN2016
-import ClimateUtilities
-import Get_Fluxes
-import OpticalThickness
-import Planck
-import SetupGrids
-import Thermodynamics
-import VerticalStructure
-import object_helpers
-import phys
+from __future__ import absolute_import
 
+from . import Absorption_Continuum
+from . import Absorption_Continuum_MTCKD
+from . import Absorption_Crosssections_HITRAN2016
+from . import ClimateUtilities
+from . import Get_Fluxes
+from . import OpticalThickness
+from . import Planck
+from . import SetupGrids
+from . import Thermodynamics
+from . import VerticalStructure
+from . import object_helpers
+from . import phys

--- a/pyrads/object_helpers.py
+++ b/pyrads/object_helpers.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 from copy import copy               # to copy lists of objects...
 
 # ==================================================================================

--- a/pyrads/object_helpers.py
+++ b/pyrads/object_helpers.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 from copy import copy               # to copy lists of objects...
 
 # ==================================================================================
@@ -18,5 +19,3 @@ def get_objects_from_list(obj_list,attribute,value,comparefn=None):
     if len(x)==1:
         x = x[0]
     return x
-
-

--- a/pyrads/phys.py
+++ b/pyrads/phys.py
@@ -1,3 +1,4 @@
+from __future__ import division, print_function
 ### THIS SCRIPT IS TAKEN FROM THE COURSEWARE OF
 ###  Pierrehumbert, 2010, Principles of Planetary Climate
 ###
@@ -32,7 +33,7 @@ from ClimateUtilities import * #To get the math methods routines
 
 #-------------Basic physical constants-------------------
 #
-#The following five are the most accurate 1986 values 
+#The following five are the most accurate 1986 values
 #
 h = 6.626075540e-34    #Planck's constant
 c = 2.99792458e8       #Speed of light
@@ -71,7 +72,7 @@ Rstar = 1000.*k*N_avogadro   #Universal gas constant
 #
 #
 #ToDo: *Add more documentation and help features
-#       
+#
 #      *provide dictionary of properties and units.
 #      *Add some methods or lists that make it easier
 #       for the user to create new gas objects and insert
@@ -120,7 +121,7 @@ class gas:
             to specific heat at constant volume. (Generally
             stated at 298K and 1bar)
         MolecularWeight: Molecular weight of the dominant isotope
-        name: Name of the gas 
+        name: Name of the gas
         formula: Chemical formula (e.g. 'CH4')
 
         L_vaporization: Default value to use for latent heat of
@@ -135,7 +136,7 @@ class gas:
             method is called
         Rcp: The adiabatic exponent R/cp. Computed from other
             data when the update() method is called.
-        
+
     '''
 
     #The __repr__ method allows us to print out
@@ -162,7 +163,7 @@ class gas:
         self.cp = None
         self.gamma = None
         self.MolecularWeight = None
-        self.name = None 
+        self.name = None
         self.formula = None
         #
         #Default values for latent heat and liquid
@@ -206,8 +207,8 @@ H2O.rho_solid = 9.170000e+02
 H2O.cp = 1.847000e+03
 H2O.gamma = 1.331000e+00
 H2O.MolecularWeight = 1.800000e+01
-H2O.name = 'Water' 
-H2O.formula = 'H2O' 
+H2O.name = 'Water'
+H2O.formula = 'H2O'
 H2O.L_vaporization=2.493000e+06
 H2O.rho_liquid=9.998700e+02
 #------------------------
@@ -226,8 +227,8 @@ CH4.rho_solid = 5.093000e+02
 CH4.cp = 2.195000e+03
 CH4.gamma = 1.305000e+00
 CH4.MolecularWeight = 1.600000e+01
-CH4.name = 'Methane' 
-CH4.formula = 'CH4' 
+CH4.name = 'Methane'
+CH4.formula = 'CH4'
 CH4.L_vaporization=5.360000e+05
 CH4.rho_liquid=4.502000e+02
 #------------------------
@@ -246,8 +247,8 @@ CO2.rho_solid = 1.562000e+03
 CO2.cp = 8.200000e+02
 CO2.gamma = 1.294000e+00
 CO2.MolecularWeight = 4.400000e+01
-CO2.name = 'Carbon Dioxide' 
-CO2.formula = 'CO2' 
+CO2.name = 'Carbon Dioxide'
+CO2.formula = 'CO2'
 CO2.L_vaporization=3.970000e+05
 CO2.rho_liquid=1.110000e+03
 #------------------------
@@ -266,8 +267,8 @@ N2.rho_solid = 1.026000e+03
 N2.cp = 1.037000e+03
 N2.gamma = 1.403000e+00
 N2.MolecularWeight = 2.800000e+01
-N2.name = 'Nitrogen' 
-N2.formula = 'N2' 
+N2.name = 'Nitrogen'
+N2.formula = 'N2'
 N2.L_vaporization=2.180000e+05
 N2.rho_liquid=8.086000e+02
 #------------------------
@@ -286,8 +287,8 @@ O2.rho_solid = 1.351000e+03
 O2.cp = 9.160000e+02
 O2.gamma = 1.393000e+00
 O2.MolecularWeight = 3.200000e+01
-O2.name = 'Oxygen' 
-O2.formula = 'O2' 
+O2.name = 'Oxygen'
+O2.formula = 'O2'
 O2.L_vaporization=2.420000e+05
 O2.rho_liquid=1.307000e+03
 #------------------------
@@ -306,8 +307,8 @@ H2.rho_solid = 8.800000e+01
 H2.cp = 1.423000e+04
 H2.gamma = 1.384000e+00
 H2.MolecularWeight = 2.000000e+00
-H2.name = 'Hydrogen' 
-H2.formula = 'H2' 
+H2.name = 'Hydrogen'
+H2.formula = 'H2'
 H2.L_vaporization=4.540000e+05
 H2.rho_liquid=7.097000e+01
 #------------------------
@@ -326,8 +327,8 @@ He.rho_solid = 2.000000e+02
 He.cp = 5.196000e+03
 He.gamma = 1.664000e+00
 He.MolecularWeight = 4.000000e+00
-He.name = 'Helium' 
-He.formula = 'He' 
+He.name = 'Helium'
+He.formula = 'He'
 He.L_vaporization=2.030000e+04
 He.rho_liquid=1.249600e+02
 #------------------------
@@ -346,8 +347,8 @@ NH3.rho_solid = 8.226000e+02
 NH3.cp = 2.060000e+03
 NH3.gamma = 1.309000e+00
 NH3.MolecularWeight = 1.700000e+01
-NH3.name = 'Ammonia' 
-NH3.formula = 'NH3' 
+NH3.name = 'Ammonia'
+NH3.formula = 'NH3'
 NH3.L_vaporization=1.658000e+06
 NH3.rho_liquid=7.342000e+02
 #------------------------
@@ -455,7 +456,7 @@ def satvpg(T):
 #the simplified form of Clausius-Clapeyron assuming the perfect
 #gas law and constant latent heat
 def satvps(T,T0,e0,MolecularWeight,LatentHeat):
-  Rv=Rstar/MolecularWeight 
+  Rv=Rstar/MolecularWeight
   return e0*math.exp(-(LatentHeat/Rv)*(1./T - 1./T0))
 
 #This example shows how to simplify the use of the simplified
@@ -654,7 +655,3 @@ class MoistAdiabat:
             mc = Numeric.array([mc1(pp) for pp in pgrid])
             q = Numeric.array([q1(pp) for pp in pgrid])
             return Numeric.array(pgrid),T, mc, q
-
-
-
-

--- a/pyrads/phys.py
+++ b/pyrads/phys.py
@@ -1,4 +1,4 @@
-from __future__ import division, print_function
+from __future__ import division, print_function, absolute_import
 ### THIS SCRIPT IS TAKEN FROM THE COURSEWARE OF
 ###  Pierrehumbert, 2010, Principles of Planetary Climate
 ###
@@ -6,7 +6,7 @@ from __future__ import division, print_function
 ###  https://geosci.uchicago.edu/~rtp1/PrinciplesPlanetaryClimate/Courseware/coursewarePortal.html
 
 import math
-from ClimateUtilities import * #To get the math methods routines
+from .ClimateUtilities import * #To get the math methods routines
 #
 #All units are mks units
 #


### PR DESCRIPTION
Closes #7 

Makes stuff work on both Python 2.7 and Python 3.x

Key changes:
- use the `future` package for interoperability. Most of the modules now have
```
from __future__ import division, print_function, absolute_import
```
at the beginning. This makes Python 2.7 code work the same as it does in Python 3.
- All the `print` statements are changed to `print()` functions
- all the local `import somemodule` statements are changed to the explicit style
```
from . import somemodule
```
- The other difference would be the meaning of the division operator `/` on integers. In Python 2 this returns a truncated `int`, while in Python 3 it always returns a `float`. I didn't **see** any usage of integer division in the code, but you have a careful look.

Finally I included a `.gitignore` file in the repository to simplify the version control of code while excluding compiled objects.