### PR TITLE
Adding setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup
+
+dependencies = ["numpy",
+                "scipy"]
+
+def readme():
+    with open('README.md') as f:
+        return f.read()
+
+setup(name='PyRADS',
+      version='0.1.0',
+      description='PyRADS is the "Python line-by-line RADiation model for planetary atmosphereS"',
+      long_description=readme(),
+      url='',
+      author='Daniel B. Koll',
+      author_email='dbkoll@mit.edu',
+      license='MIT',
+      packages=['pyrads'],
+      install_requires=dependencies,
+      zip_safe=False)


### PR DESCRIPTION
Attempt to close #6 , not sure about how to use `f2py` to build the MTCKD code though.

This PR adds a simple setup.py so that the (non-fortran?) parts can be installed like:

```
git clone https://github.com/ddbkoll/PyRADS.git

cd PyRADS

pip install .
```

